### PR TITLE
ci(deploy): add prepare step

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:e2e": "vue-cli-service test:e2e --browser chrome",
     "lint": "vue-cli-service lint",
     "lint:ci": "vue-cli-service lint --no-fix --max-warnings 0",
+    "prepare": "run-s build",
     "prepublishOnly": "run-s build",
     "release:dryRun": "npx node-env-run --exec 'npx semantic-release --dryRun'"
   },


### PR DESCRIPTION
Adds additional scripts to ensure properly updated `dist` prior to release.

# Before

Library is not guaranteed to execute a `build` step to properly update `dist` directory prior to deployment; as a result, some libraries include the prior release in their `dist` folder.

# After

We include both a `prepare` and a `prepublishOnly` step to ensure that the library executes a build prior to deploying a release.