### PR TITLE
fix: expose types in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "contributors": [
     "Frederick Fogerty <frederick.fogerty@gmail.com> (https://github.com/frederickfogerty)"
   ],
+  "types": "src/plugins/imgix-vue",
   "license": "BSD-2-Clause",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

This exposes the typescript declaration files for typescript to reference when used in a project. This is the simplest way to accomplish this since the plugin type files are already included in the package. However, a more involved solution would be to add a build step for the compiled types to be included in the `/dist` directory.

Before this PR typescript users would run into type errors while importing the package:

<img width="739" alt="image" src="https://github.com/imgix/vue/assets/6923792/f832f68f-67c1-4cda-b159-64c4be79f17e">


After this PR, typescript will automatically infer the types for the exported functions/classes:

<img width="426" alt="image" src="https://github.com/imgix/vue/assets/6923792/f16f2565-b92a-4502-bd52-3f348e4d8164">


## Checklist

<!-- For all Pull Requests -->

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [ ] Update the readme (if applicable).
- [ ] Update or add any necessary API documentation (if applicable)
- [ ] All existing unit tests are still passing (if applicable).