### PR TITLE
fix(readme):remove html encoding from parameter strings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,6 @@
   "editor.formatOnSave": false,
   "vetur.validation.template": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
 }

--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ This will generate HTML similar to the following:
   src="https://assets.imgix.net/examples/pione.jpg?auto=format"
   sizes="100vw"
   srcset="
-    https://assets.imgix.net/examples/pione.jpg?auto=format&amp;w=100 100w,
-    https://assets.imgix.net/examples/pione.jpg?auto=format&amp;w=200 200w,
+    https://assets.imgix.net/examples/pione.jpg?auto=format&w=100 100w,
+    https://assets.imgix.net/examples/pione.jpg?auto=format&w=200 200w,
     ...
   "
 />


### PR DESCRIPTION
## Description
Correct readme instructions to use "&" instead of "&amp;" to chain parameters.
Same for output HTML code snippets.